### PR TITLE
[Fixed] Issue of environment variables for production 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,12 @@ jobs:
         touch droplet_key
         echo "$DROPLET_KEY" > droplet_key
 
+    - name: Create environment variables
+      run: |
+        set -a
+        source prometheus-docker.env
+        set +a
+
     - name: Build Prometheus
       run: ember build --environment=$ENVIRONMENT
 


### PR DESCRIPTION
When a **PR** is merged then **_cd_** workflow is triggered. That workflow creates an build of application and deploy **_dist_** to production.

So while creating _build_ there was an issue of environment variables that we use to set our configuration of _**application**_. E.g setting _**api host**_ for our production we rely on _**environment variables**._.

For that purpose **_cd_** workflow environment should create _**env vars**_ before creating a build of application for production.